### PR TITLE
use ios 32bit only by Leia, on Matrix no more supported

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -81,6 +81,8 @@ def call(Map addonParams = [:])
 	for (int i = 0; i < platforms.size(); ++i)
 	{
 		String platform = platforms[i]
+		if (platform == 'ios-armv7' && version != 'Leia')
+			continue;
 
 		def category = "binary-addons/${platform}-${version}"
 		if (ThrottleJobProperty.fetchDescriptor().getCategories().every{ c -> c.getCategoryName() !=  category})


### PR DESCRIPTION
Example try of one way and to ask about another way.

With this change it becomes only done by Leia, but not nice todo on every round.

Another way could be also to remove `'ios-armv7': 'ios',` from `PLATFORMS_VALID` for all, as it also not deploy his build. But then a bit harder to see Failures if somerthing different between both.

A third way could be to use a different `PLATFORMS_VALID` for the versions, but then much bigger and other checks needed.

Any idea about best way or could be this here enough?

EDIT: Also must his worked confirmed inside Jenkins.