### PR TITLE
separate PLATFORMS_VALID for Matrix and Leia

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -74,7 +74,13 @@ def call(Map addonParams = [:])
 		])
 	])
 
-	def version = addonParams.containsKey('version') && addonParams.version in VERSIONS_VALID ? addonParams.version : VERSIONS_VALID.keySet()[0]
+	if (!addonParams.containsKey('version') || !(addonParams.version in VERSIONS_VALID))
+	{
+		error 'No valid Kodi version given by addon'
+		return
+	}
+
+	def version = addonParams.version
 	if (version == "Leia")
 	{
 		PLATFORMS_VALID = PLATFORMS_VALID_LEIA

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -7,7 +7,7 @@ import com.cwctravel.hudson.plugins.extended_choice_parameter.ExtendedChoicePara
 def call(Map addonParams = [:])
 {
 
-	def PLATFORMS_VALID = [
+	def PLATFORMS_VALID_LEIA = [
 		'android-armv7': 'android',
 		'android-aarch64': 'android-arm64-v8a',
 		'ios-armv7': 'ios',
@@ -17,6 +17,17 @@ def call(Map addonParams = [:])
 		'windows-i686': 'windows/win32',
 		'windows-x86_64': 'windows/x64'
 	]
+	def PLATFORMS_VALID_CURRENT = [
+		'android-armv7': 'android',
+		'android-aarch64': 'android-arm64-v8a',
+		'tvos-aarch64': 'tvos',
+		'ios-aarch64': 'ios',
+		'osx-x86_64': 'osx64',
+		'ubuntu-ppa': 'linux',
+		'windows-i686': 'windows/win32',
+		'windows-x86_64': 'windows/x64'
+	]
+	def PLATFORMS_VALID = [:]
 	def PLATFORMS_DEPLOY = [
 		'android-armv7',
 		'android-aarch64',
@@ -63,10 +74,18 @@ def call(Map addonParams = [:])
 		])
 	])
 
-	def deployPlatforms = params.deployPlatforms.tokenize(',')
-	def platforms = addonParams.containsKey('platforms') && addonParams.platforms.metaClass.respondsTo('each') && addonParams.platforms.every{ p -> p in PLATFORMS_VALID } ? addonParams.platforms : PLATFORMS_VALID.keySet()
-	def deploy = addonParams.containsKey('deploy') && addonParams.deploy.metaClass.respondsTo('each') ? addonParams.deploy.findAll{ d -> d in platforms && d in PLATFORMS_DEPLOY && d in deployPlatforms } : PLATFORMS_DEPLOY
 	def version = addonParams.containsKey('version') && addonParams.version in VERSIONS_VALID ? addonParams.version : VERSIONS_VALID.keySet()[0]
+	if (version == "Leia")
+	{
+		PLATFORMS_VALID = PLATFORMS_VALID_LEIA
+	}
+	else
+	{
+		PLATFORMS_VALID = PLATFORMS_VALID_CURRENT
+	}
+	def platforms = addonParams.containsKey('platforms') && addonParams.platforms.metaClass.respondsTo('each') && addonParams.platforms.every{ p -> p in PLATFORMS_VALID } ? addonParams.platforms : PLATFORMS_VALID.keySet()
+	def deployPlatforms = params.deployPlatforms.tokenize(',')
+	def deploy = addonParams.containsKey('deploy') && addonParams.deploy.metaClass.respondsTo('each') ? addonParams.deploy.findAll{ d -> d in platforms && d in PLATFORMS_DEPLOY && d in deployPlatforms } : PLATFORMS_DEPLOY
 	def addon = env.JOB_NAME.tokenize('/')[1]
 	/**
 	 * Definition in case if an addon source code contains several addons,


### PR DESCRIPTION
On Kodi Matrix the ios-armv7 no more supported.

This is another attempt to ask about a way to fix it.

With them I'm also not like, one thing is for Leia it is missing, the other is "tvos" only on Matrix.

What is the correct way to fix this problem?

Alternative to https://github.com/xbmc/pipeline-library/pull/8