### PR TITLE
split publishing in 2 steps: upload and processing server side

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -220,17 +220,24 @@ def call(Map addonParams = [:])
 									sshPublisher(
 										publishers: [
 											sshPublisherDesc(
-												configName: 'Mirrors',
+												configName: 'mirrors-upload',
 												transfers: [
 													sshTransfer(
-														execCommand: """/usr/local/bin/move_addons.sh ${archiveName} ${versionFolder} ${platform} >> jenkins-upload.log 2>&1""",
-														remoteDirectory: 'upload',
 														removePrefix: 'cmake/addons/build/zips/',
 														sourceFiles: "cmake/addons/build/zips/${archiveName}+${platform}/${archiveName}-*.zip"
 													)
 												]
+											),
+											sshPublisherDesc(
+												configName: 'jenkins-move-addons',
+												transfers: [
+													sshTransfer(
+														execCommand: """jenkins-move-addons.sh ${archiveName} ${versionFolder} ${platform}"""
+												    )
+												]
 											)
 										]
+
 									)
 								}
 							}


### PR DESCRIPTION
This allows more control and therefore better security on the server side.
We first upload with a chrooted user, then calls a restricted post processing script with another user.

Jenkins and Mirrors are already prepared.