### PR TITLE
check for addon build failure

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -202,6 +202,9 @@ def call(Map addonParams = [:])
 								if (isUnix())
 									sh "grep '${addon}' cmake/addons/.success"
 
+								if (fileExists("cmake/addons/.failure"))
+									error "addon build failed"
+
 								currentBuild.result = 'SUCCESS'
 							}
 


### PR DESCRIPTION
I'm not sure why the bat scripts don't capture the exit status, nor do I really care to try and debug it.

Let's just fail if the `.failure` file exists