### PR TITLE
Fix built result

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -284,10 +284,10 @@ def call(Map addonParams = [:])
 						def packageversion
 						def changespattern = [:]
 						def dists = params.dists.tokenize(',')
-						def ppas = params.PPA == "auto" ? [PPA_VERSION_MAP[version].each{p -> PPAS_VALID[p]}].flatten() : []
+						def ppas = (params.PPA == "auto" && PPA_VERSION_MAP.containsKey(version)) ? [PPA_VERSION_MAP[version].each{p -> PPAS_VALID[p]}].flatten() : []
 						if (ppas.size() == 0)
 						{
-							params.PPA.tokenize(',').each{p -> ppas.add(PPAS_VALID[p])}
+							params.PPA.tokenize(',').each{p -> if (PPAS_VALID.containsKey(p)) ppas.add(PPAS_VALID[p])}
 						}
 
 						platformResult["${platform}"] = 'UNKNOWN'
@@ -347,7 +347,7 @@ def call(Map addonParams = [:])
 								platformResult["${platform}"] = 'SUCCESS'
 							}
 
-							if (env.TAG_NAME != null || params.force_ppa_upload)
+							if ((env.TAG_NAME != null && ppas.size() > 0) || params.force_ppa_upload)
 							{
 								stage("deploy ${platform}")
 								{

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -222,9 +222,9 @@ def call(Map addonParams = [:])
 								archiveArtifacts artifacts: "cmake/addons/build/zips/${archiveName}+${platform}/${archiveName}-*.zip"
 							}
 
-							stage("deploy (${platform})")
+							if (platform in deploy && env.TAG_NAME != null)
 							{
-								if (platform in deploy && env.TAG_NAME != null)
+								stage("deploy (${platform})")
 								{
 									echo "Deploying: ${addon} ${env.TAG_NAME}"
 									versionFolder = VERSIONS_VALID[version]
@@ -244,11 +244,10 @@ def call(Map addonParams = [:])
 												transfers: [
 													sshTransfer(
 														execCommand: """jenkins-move-addons.sh ${archiveName} ${versionFolder} ${platform}"""
-												    )
+													)
 												]
 											)
 										]
-
 									)
 								}
 							}
@@ -348,9 +347,9 @@ def call(Map addonParams = [:])
 								platformResult["${platform}"] = 'SUCCESS'
 							}
 
-							stage("deploy ${platform}")
+							if (env.TAG_NAME != null || params.force_ppa_upload)
 							{
-								if (env.TAG_NAME != null || params.force_ppa_upload)
+								stage("deploy ${platform}")
 								{
 									def force = params.force_ppa_upload ? '-f' : ''
 									def done = 0
@@ -358,7 +357,7 @@ def call(Map addonParams = [:])
 									{
 										for (dist in changespattern.keySet())
 										{
-										        if (UBUNTU_DISTS[ppa].contains(dist))
+											if (UBUNTU_DISTS[ppa].contains(dist))
 											{
 												echo "Uploading ${changespattern[dist]} to ${PPAS_VALID[ppa]}"
 												sh "dput ${force} ${PPAS_VALID[ppa]} ${changespattern[dist]}"

--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -103,6 +103,8 @@ def call(Map addonParams = [:])
 
 	env.Configuration = 'Release'
 
+	currentBuild.result = 'SUCCESS'
+
 	for (int i = 0; i < platforms.size(); ++i)
 	{
 		String platform = platforms[i]
@@ -199,13 +201,14 @@ def call(Map addonParams = [:])
 									bat "tools/buildsteps/${folder}/make-addons.bat package ${addon}"
 								}
 
-								if (isUnix())
-									sh "grep '${addon}' cmake/addons/.success"
-
-								if (fileExists("cmake/addons/.failure"))
-									error "addon build failed"
-
-								currentBuild.result = 'SUCCESS'
+								if (fileExists("cmake/addons/.success"))
+								{
+									echo "Successfully built addon: ${addon}"
+								}
+								else if (fileExists("cmake/addons/.failure"))
+								{
+									error "Failed to build addon: ${addon}"
+								}
 							}
 
 							stage("archive (${platform})")
@@ -246,6 +249,7 @@ def call(Map addonParams = [:])
 						}
 						catch (error)
 						{
+							echo "Build failed: ${error}"
 							currentBuild.result  = 'FAILURE'
 						}
 						finally
@@ -331,8 +335,6 @@ def call(Map addonParams = [:])
 										sh "debuild -d -S -k'jenkins (jenkins build bot) <jenkins@kodi.tv>'"
 									}
 								}
-
-								currentBuild.result = 'SUCCESS'
 							}
 
 							stage("deploy ${platform}")
@@ -364,6 +366,7 @@ def call(Map addonParams = [:])
 						}
 						catch (error)
 						{
+							echo "Build failed: ${error}"
 							currentBuild.result = 'FAILURE'
 						}
 						finally


### PR DESCRIPTION
This PR aims to fix a combination of problems:

1) f854e56 `currentBuild.result` seems to set the global result, so we want to set this if any stage for any platform fails.
2) f369823 We want to track the build status of each platform individually for the slack notifier, this can be done with the map `platformResult`. Jenkins doesn't seem to have (or that I could find) an individual step variable to flag the result of each step per parallel build.
3) ab1aeb8 Only run the deploy step if the platform is deployable and it's a release
4) 65b9db9 Add some guards to the ubuntu ppa's in the case that a version (Leia) isn't deployable.