### PR TITLE
[ubuntu ppa] add epoch to package versions

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -286,6 +286,7 @@ def call(Map addonParams = [:])
 					ws("workspace/binary-addons/kodi-${platform}-${version}")
 					{
 						def packageversion
+						def epoch = 6
 						def changespattern = [:]
 						def dists = params.dists.tokenize(',')
 						def ppas = (params.PPA == "auto" && PPA_VERSION_MAP.containsKey(version)) ? [PPA_VERSION_MAP[version].each{p -> PPAS_VALID[p]}].flatten() : []
@@ -330,6 +331,7 @@ def call(Map addonParams = [:])
 									echo "Ubuntu dists enabled: ${dists} - TAGREV: ${params.TAGREV} - PPA: ${params.PPA}"
 									def addonsxml = readFile "${addon}/addon.xml.in"
 									packageversion = getVersion(addonsxml)
+									debversion = epoch + ":" + packageversion
 									echo "Detected PackageVersion: ${packageversion}"
 									def changelogin = readFile 'debian/changelog.in'
 									def origtarball = 'kodi-' + addon.replace('.', '-') + "_${packageversion}.orig.tar.gz"
@@ -340,7 +342,7 @@ def call(Map addonParams = [:])
 									{
 										dist = dist.trim()
 										echo "Building debian-source package for ${dist}"
-										def changelog = changelogin.replace('#PACKAGEVERSION#', packageversion).replace('#TAGREV#', params.TAGREV).replace('#DIST#', dist)
+										def changelog = changelogin.replace('#PACKAGEVERSION#', debversion).replace('#TAGREV#', params.TAGREV).replace('#DIST#', dist)
 										def pattern = 'kodi-' + addon.replace('.', '-') + "_${packageversion}-${params.TAGREV}*${dist}_source.changes"
 										changespattern.put(dist, pattern)
 										writeFile file: "debian/changelog", text: "${changelog}"


### PR DESCRIPTION
as discussed with @basilgello 

We always want to have a higher debian package version than what official debian/ubuntu repos provide, so our packages have priority.
Solve this by setting debian epoch to 6, which is higher then any know epoch used for kodi in debian repos 