### PR TITLE
[windows] add pdb related env vars

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -212,7 +212,14 @@ def call(Map addonParams = [:])
 									env.ADDONS_DEFINITION_DIR = pwd().replace('\\', '/') + '/tools/depends/target/binary-addons/addons'
 									env.ADDON_SRC_PREFIX = pwd().replace('\\', '/') + '/tools/depends/target/binary-addons'
 									folder = PLATFORMS_VALID[platform]
-									bat "tools/buildsteps/${folder}/make-addons.bat package ${addon}"
+									bat """
+									  set MAXTHREADS=24
+									  set TEMP=project/BuildDependencies/scripts/tmp
+									  set TMP=project/BuildDependencies/scripts/tmp
+									  set TMPDIR=project/BuildDependencies/scripts/tmp
+									  set _MSPDBSRV_ENDPOINT_=${BUILD_TAG}
+									  tools/buildsteps/${folder}/make-addons.bat package ${addon}
+									"""
 								}
 
 								if (fileExists("cmake/addons/.success"))


### PR DESCRIPTION
This sets env vars to hopefully reduce pdb linker failures. These variables are implemented for core kodi at the individual job level (WIN-64, WIN-32, etc) already. Add to reduce failures for addon pipeline jobs

@wsnipex Ive no idea how to test this. The theory comes from https://issues.jenkins.io/browse/JENKINS-9104?focusedCommentId=360603&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-360603 for the pipeline change.
Obviously all these env vars are already in place for core, and it seems to have reduced/eliminated the pdb linker failures in core builds

@lrusak maybe you can give insight into how to test this before merge as well maybe...