### PR TITLE
fix building Omega binary add-ons

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -144,7 +144,7 @@ def call(Map addonParams = [:])
 							stage("prepare (${platform})")
 							{
 								pwd = pwd()
-								kodiBranch = version == "Omega" ? "master" : version
+								kodiBranch = version
 								checkout([
 									changelog: false,
 									scm: [


### PR DESCRIPTION
add-ons were being built against master instead of the Omega branch