### PR TITLE
[Piers] Use master branch of kodi for Piers addons branch

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -108,7 +108,7 @@ def call(Map addonParams = [:])
 							stage("prepare (${platform})")
 							{
 								pwd = pwd()
-								kodiBranch = version
+								kodiBranch = version == "Piers" ? "master" : version
 								checkout([
 									changelog: false,
 									scm: [


### PR DESCRIPTION
Really need to make an easier way to more generally handle master branch being unnamed for pre release version. but quick fix is good for now.