### PR TITLE
[addons] Set buildDiscarder values for addons

### DIFF
--- a/vars/buildPlugin.groovy
+++ b/vars/buildPlugin.groovy
@@ -52,7 +52,7 @@ def call(Map addonParams = [:])
 	]
 
 	properties([
-		buildDiscarder(logRotator(artifactDaysToKeepStr: '', artifactNumToKeepStr: '', daysToKeepStr: '', numToKeepStr: '5')),
+		buildDiscarder(logRotator(artifactDaysToKeepStr: '5', artifactNumToKeepStr: '5', daysToKeepStr: '7', numToKeepStr: '5')),
 		disableConcurrentBuilds(),
 		disableResume(),
 		durabilityHint('PERFORMANCE_OPTIMIZED'),


### PR DESCRIPTION
Parameters for logRotator (from [the source code](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/tasks/LogRotator.java#L87)):

daysToKeepStr: history is only kept up to this days.
numToKeepStr: only this number of build logs are kept.
artifactDaysToKeepStr: artifacts are only kept up to this days.
artifactNumToKeepStr: only this number of builds have their artifacts kept.

Feel free to suggest any values you see relevant. I figure a log for a week, artifact for 5 days. Gives some time to get to logs, whilst dealing with ksooo's concerns.