### PR TITLE
Force second -f parameter

### DIFF
--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -243,7 +243,7 @@ def call(Map buildParams = [:]) {
                         env.DEBUG_SWITCH = env.CONFIGURATION == 'Release' ? '--disable-debug' : '--enable-debug'
                         sh 'bash -c "\
                           cd $WORKSPACE/tools/depends \
-                          && git clean -xfd . \
+                          && git clean -f -xfd . \
                           && ./bootstrap \
                           && ./configure \
                             --with-tarballs=$TARBALLS_DIR \


### PR DESCRIPTION
Git man pages state the following (https://git-scm.com/docs/git-clean#Documentation/git-clean.txt---force)

```
-f
--force

If the Git configuration variable clean.requireForce is not set to false, git clean will refuse to delete files
or directories unless given -f. Git will refuse to modify untracked nested git repositories (directories
with a .git subdirectory) unless a second -f is given.
```

webos is getting phantom find configs in omega nightlies that has caused failures for months. 

the following is in nightly logs

```
Skipping repository target/binary-addons/arm-webos-linux-gnueabi-debug/build/bootstrap/binary-addons/src/binary-addons
Skipping repository target/binary-addons/arm-webos-linux-gnueabi-release/build/bootstrap/binary-addons/src/binary-addons
```

I dont believe this will fix anything, but at least it should force cleanup the workspace appropriately.