### PR TITLE
Android move gradle cache to platform folders

### DIFF
--- a/vars/buildKodi.groovy
+++ b/vars/buildKodi.groovy
@@ -32,7 +32,7 @@ def call(Map buildParams = [:]) {
     def defaultImage = platform =~ /Linux/ ? 'kodi/jenkins/linux-arm:latest' : 'kodi/jenkins/android-build:latest'
     def buildImage = buildParams.containsKey('image') ? buildParams.image : defaultImage
     def renderSystem = buildParams.containsKey('rendersystem') && renderSystemsValid.contains(buildParams.rendersystem) ? buildParams.rendersystem : params.RENDERSYSTEM
-    def extraMount = platform =~ /Android/ ? '-v /home/jenkins/android-tools/signing:/home/jenkins/android-tools/signing:ro -v /home/jenkins/jenkins-root/workspace/.gradle:/home/jenkins/.gradle:rw' : ''
+    def extraMount = platform =~ /Android/ ? "-v /home/jenkins/android-tools/signing:/home/jenkins/android-tools/signing:ro -v /home/jenkins/jenkins-root/workspace/${platform}/.gradle:/home/jenkins/.gradle:rw" : ''
     def ccacheDir = '.ccache' + platform
 
     def uploadArtifact = (env.UPLOAD_RESULT == true || env.UPLOAD_RESULT == 'true' || env.UPLOAD_RESULT == 'True') ? true : params.UPLOAD_RESULT


### PR DESCRIPTION
Issue is the following error on CI

```
         > Cannot create service of type GlobalCacheLocations using method GradleUserHomeScopeServices.createGlobalCacheLocations() as there is a problem with parameter #1 of type List<GlobalCache>.
            > Could not create service of type FileAccessTimeJournal using GradleUserHomeScopeServices.createFileAccessTimeJournal().
               > Timeout waiting to lock journal cache (/home/jenkins/.gradle/caches/journal-1). It is currently in use by another process.
                 Owner PID: 480805
                 Our PID: 480590
                 Owner Operation: 
                 Our operation: 
                 Lock file: /home/jenkins/.gradle/caches/journal-1/journal-1.lock
```

Gradle open issue for reference on their stance - https://github.com/gradle/gradle/issues/8375
They have a bunch of closed duplicates, and this stems back years, so i doubt theres going to be any "fix" coming from gradle.

Two commits, but ideally we would try to stick with commit 2 (platform folder for cache). I can drop whatever path we choose not to use

~~First just removes any attempt at caching of the ``.gradle`` folder. Sledgehammer approach. Would cause redownloading gradle data every run. Not ideal, but should skip the above issue. Will use considerably more bandwidth and space~~

Second commit would keep cache folder usage, however it would limit it to a platfom folder. As we currently only run a single platform CI job at a time, there should be no lock contention, as there will only be the single platform job.
This would still allow caching across platforms, but it will still increase disk usage (x MB per platform - currently 3)

@wsnipex anything you can comment on at all if you have time?